### PR TITLE
add supporting for multiple bytes of address header and ps2h header

### DIFF
--- a/const.go
+++ b/const.go
@@ -32,24 +32,24 @@ var (
 	//BitcoinMain is params for main net.
 	BitcoinMain = &Params{
 		DumpedPrivateKeyHeader: []byte{128},
-		AddressHeader:          0,
-		P2SHHeader:             5,
+		AddressHeader:          []byte{0},
+		P2SHHeader:             []byte{5},
 		HDPrivateKeyID:         []byte{0x04, 0x88, 0xad, 0xe4},
 		HDPublicKeyID:          []byte{0x04, 0x88, 0xb2, 0x1e},
 	}
 	//BitcoinTest is params for test net.
 	BitcoinTest = &Params{
 		DumpedPrivateKeyHeader: []byte{239},
-		AddressHeader:          111,
-		P2SHHeader:             196,
+		AddressHeader:          []byte{111},
+		P2SHHeader:             []byte{196},
 		HDPrivateKeyID:         []byte{0x04, 0x35, 0x83, 0x94},
 		HDPublicKeyID:          []byte{0x04, 0x35, 0x87, 0xcf},
 	}
 	//MonacoinMain is params for monacoin main net.
 	MonacoinMain = &Params{
 		DumpedPrivateKeyHeader: []byte{178, 176},
-		AddressHeader:          50,
-		P2SHHeader:             5,
+		AddressHeader:          []byte{50},
+		P2SHHeader:             []byte{5},
 		HDPrivateKeyID:         []byte{0x04, 0x88, 0xad, 0xe4},
 		HDPublicKeyID:          []byte{0x04, 0x88, 0xb2, 0x1e},
 	}

--- a/key.go
+++ b/key.go
@@ -46,8 +46,8 @@ var (
 //Params is parameters of the coin.
 type Params struct {
 	DumpedPrivateKeyHeader []byte
-	AddressHeader          byte
-	P2SHHeader             byte
+	AddressHeader          []byte
+	P2SHHeader             []byte
 	HDPrivateKeyID         []byte
 	HDPublicKeyID          []byte
 }
@@ -192,9 +192,7 @@ func (pub *PublicKey) AddressBytes() []byte {
 //Address returns bitcoin address from PublicKey
 func (pub *PublicKey) Address() string {
 	ripeHashedBytes := pub.AddressBytes()
-	ripeHashedBytes = append(ripeHashedBytes, 0x0)
-	copy(ripeHashedBytes[1:], ripeHashedBytes[:len(ripeHashedBytes)-1])
-	ripeHashedBytes[0] = pub.param.AddressHeader
+	ripeHashedBytes = append(pub.param.AddressHeader, ripeHashedBytes...)
 
 	return base58.Encode(ripeHashedBytes)
 }


### PR DESCRIPTION
For crypto currencies, like zcash, the length of its address header is two bytes. 